### PR TITLE
Replace "move_toward" with new "exponential_decay" function

### DIFF
--- a/addons/Basic FPS Player/Src/basic_player_startup.gd
+++ b/addons/Basic FPS Player/Src/basic_player_startup.gd
@@ -153,8 +153,18 @@ func move_player(delta):
 	var input_dir = Input.get_vector(KEY_BIND_LEFT, KEY_BIND_RIGHT, KEY_BIND_UP, KEY_BIND_DOWN)
 	var direction = (transform.basis * Vector3(input_dir.x, 0, input_dir.y)).normalized()
 	
-	velocity.x = move_toward(velocity.x, direction.x * speed, accel * delta)
-	velocity.z = move_toward(velocity.z, direction.z * speed, accel * delta)
+	velocity.x = exponential_decay(
+		velocity.x,
+		direction.x * speed,
+		accel,
+		delta
+	)
+	velocity.z = exponential_decay(
+		velocity.z,
+		direction.z * speed,
+		accel,
+		delta
+	)
 
 	move_and_slide()
 
@@ -169,3 +179,6 @@ func reset_head_bob(delta):
 	if $Head.position == head_start_pos:
 		pass
 	$Head.position = lerp($Head.position, head_start_pos, 2 * (1/HEAD_BOB_FREQUENCY) * delta)
+
+func exponential_decay(a:float, b:float, decay:float, delta:float) -> float:
+	return b + (a - b) * exp(-decay * delta)


### PR DESCRIPTION
I've never done a pull request before so I hope I'm doing this right!
I recently used this add-on for a game but I noticed slight "lurches" in the movement when starting/stopping when the player is rotated on a slight diagonal. I added in an "exponential decay" function that remedied this while still being framerate-independent.

For comparison, I recorded 2 clips of myself walking back and forth in-game with head bobbing turned off. (Apologies for the extra visuals and such, it was the easiest way to demonstrate what I'm addressing)

Here it is with move_toward, look closely at the gap between the 2 buildings within the crosshair. Note how, despite only moving forward and backward, there is a slight sideways lurch when starting and stopping movement.

https://github.com/user-attachments/assets/a7c1d462-1f9c-40a1-a880-10acd8dd117d

Here it is with exponential_decay, note the lack of lurch upon starting/stopping.

https://github.com/user-attachments/assets/cb0bf6f1-81a5-4026-9150-2ea08a60e4d6

Love the plug-in, hoping this can be helpful to anyone using it in the future!